### PR TITLE
Improve: エディタ・Storybookを新規タブで開くようにする

### DIFF
--- a/scripts/collect.ts
+++ b/scripts/collect.ts
@@ -284,8 +284,8 @@ for (const { dirname, source } of successfulDownloads) {
   const deployInfoMessage = [
     ":rocket: プレビュー用ページを作成しました :rocket:",
     "",
-    `- [:pencil: エディタ](${pagesUrl}/preview/${dirname}/editor)`,
-    `- [:book: Storybook](${pagesUrl}/preview/${dirname}/storybook)`,
+    `- <a href="${pagesUrl}/preview/${dirname}/editor" target="_blank">:pencil: エディタ</a>`,
+    `- <a href="${pagesUrl}/preview/${dirname}/storybook" target="_blank">:book: Storybook</a>`,
     "",
     `更新時点でのコミットハッシュ：[\`${source.pullRequest.head.sha.slice(0, 7)}\`](https://github.com/${
       source.pullRequest.head.repo.full_name


### PR DESCRIPTION
## 内容

エディタ/Storybookを新規タブで開くようにします。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

試しにエディタを新規タブで開くようにしたコメント（手動編集）： https://github.com/VOICEVOX/voicevox/pull/2303#issuecomment-2462019406