### PR TITLE
ci: merge-gatekeeperを導入する

### DIFF
--- a/.github/workflows/merge_gatekeeper.yml
+++ b/.github/workflows/merge_gatekeeper.yml
@@ -1,0 +1,30 @@
+name: "Merge Gatekeeper"
+
+# auto mergeとmerge queue用のチェッカー。
+# Approve数が足りているか、すべてのテストが通っているかを確認します。
+# 詳細： https://github.com/VOICEVOX/merge-gatekeeper
+
+on:
+  pull_request_target:
+    types: [auto_merge_enabled]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  merge_gatekeeper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: voicevox/merge-gatekeeper@main
+        with:
+          token: ${{ secrets.GATEKEEPER_TOKEN }}
+          required_score: 2
+          score_rules: |
+            #maintainer: 2
+            #reviewer: 1
+      - uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          self: merge_gatekeeper
+          # https://github.com/upsidr/merge-gatekeeper/issues/71#issuecomment-1660607977
+          ref: ${{ github.event.pull_request && github.event.pull_request.head.sha || github.ref }}
+          timeout: 18000 # 5 hours

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: "Test"
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
## 内容

やはりあると便利なので！

## その他

`test.yml`のpushをmainブランチ以外でも稼働するようにしたのですが、`test.yml`の↓のコードってpush環境でも動きそうでしょうか･･･？

```yaml
      - name: Test Dry Run
        run: |
          pnpm run run:collect-artifacts --skipDownload
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

動かないならこのステップはmainブランチor`pull_request`でのみ実行するように変えます。