### PR TITLE
chore: 子ロガーのフォーマットを少し変える

### DIFF
--- a/scripts/collectArtifacts.ts
+++ b/scripts/collectArtifacts.ts
@@ -141,11 +141,13 @@ async function collectArtifact(
 ): Promise<DownloadData | undefined> {
   const [targetRepoOwner, targetRepoName] =
     targetRepos[repoKey].repo.split("/");
-  const log = rootLogger.getChild(
-    source.type === "branch"
-      ? `Branch ${source.branch.name}`
-      : `PR #${source.pullRequest.number}`,
-  );
+  const log = rootLogger
+    .getChild(repoKey)
+    .getChild(
+      source.type === "branch"
+        ? `Branch ${source.branch.name}`
+        : `PR #${source.pullRequest.number}`,
+    );
 
   try {
     const jobAndRunId = await getJobAndRunId(

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -54,6 +54,8 @@ await logtape.configure({
       formatter: logtape.getAnsiColorFormatter({
         level: "full",
         categoryColor: "cyan",
+        category: (categories: readonly string[]) =>
+          `[${categories.join("][")}]`,
       }),
     }),
   },


### PR DESCRIPTION
## 内容

logtapeのカテゴリを`・`の結合から`[a][b]`のようにします。また、ダウンロード段階もリポジトリをロガーにつけるようにします。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）