### PR TITLE
ci: pinact でGitHub Actionsのバージョンを固定する

### DIFF
--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+
+files:
+  - pattern: ".github/workflows/*.yml"
+  - pattern: ".github/actions/*/action.yml"
+  - pattern: "base/action.yml"
+
+ignore_actions:
+  - name: voicevox/merge-gatekeeper
+    ref: main

--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".node-version"
           cache: "pnpm"

--- a/.github/workflows/merge_gatekeeper.yml
+++ b/.github/workflows/merge_gatekeeper.yml
@@ -21,7 +21,7 @@ jobs:
           score_rules: |
             #maintainer: 2
             #reviewer: 1
-      - uses: upsidr/merge-gatekeeper@v1
+      - uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           self: merge_gatekeeper

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".node-version"
           cache: "pnpm"
@@ -26,6 +26,12 @@ jobs:
       - name: Lint
         run: |
           pnpm run lint
+
+      - name: Check pinact
+        uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
+        with:
+          skip_push: "true"
+          min_age: "7"
 
       - name: Test Dry Run
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,14 @@ jobs:
         run: |
           pnpm run lint
 
-      - name: Test Dry Run
-        run: |
-          pnpm run run:collect-artifacts --fetchUrlOnly
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Check pinact
         uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
         with:
           skip_push: "true"
           min_age: "7"
+
+      - name: Test Dry Run
+        run: |
+          pnpm run run:collect-artifacts --fetchUrlOnly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,14 @@ jobs:
         run: |
           pnpm run lint
 
-      - name: Check pinact
-        uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
-        with:
-          skip_push: "true"
-          min_age: "7"
-
       - name: Test Dry Run
         run: |
           pnpm run run:collect-artifacts --fetchUrlOnly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check pinact
+        uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
+        with:
+          skip_push: "true"
+          min_age: "7"

--- a/.github/workflows/update_pages.yml
+++ b/.github/workflows/update_pages.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".node-version"
           cache: "pnpm"
@@ -48,16 +48,16 @@ jobs:
           pnpm run build --base /preview-pages
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: "./dist"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
       - name: Update Comments
         run: |

--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ jobs:
 
 </details>
 
+## GitHub Actions のバージョン固定
+
+[pinact](https://github.com/suzuki-shunsuke/pinact) を使って GitHub Actions のバージョンを full-length commit SHA に固定しています。
+プルリクエストを送ると自動でテストされます。
+
+```bash
+# バージョンを固定する
+pinact run
+
+# バージョンを更新して固定する
+pinact run --update --min-age 7
+```
+
 ## ライセンス
 
 [LICENSE](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -183,20 +183,6 @@ jobs:
 ```
 
 </details>
-
-## GitHub Actions のバージョン固定
-
-[pinact](https://github.com/suzuki-shunsuke/pinact) を使って GitHub Actions のバージョンを full-length commit SHA に固定しています。
-プルリクエストを送ると自動でテストされます。
-
-```bash
-# バージョンを固定する
-pinact run
-
-# バージョンを更新して固定する
-pinact run --update --min-age 7
-```
-
 ## ライセンス
 
 [LICENSE](LICENSE) を参照してください。

--- a/base/action.yml
+++ b/base/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Determine base URL
-      uses: actions/github-script@v4
+      uses: actions/github-script@10b53a9ec6c222bb4ce97aa6bd2b5f739696b536 # v4.2.0
       id: determine_base_url
       with:
         script: |


### PR DESCRIPTION
## 内容

pinact で GitHub Actions のバージョンを full-length commit SHA にピン留めする。

## 関連 Issue

ref VOICEVOX/voicevox_project#82